### PR TITLE
Update README for Turkish-German learners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # Vocabulary Mobile App
 
-This project is intended to become a mobile application for building and managing a personal vocabulary. While no source code is currently available, the following feature ideas outline planned functionality:
+A vocabulary learning app for native Turkish speakers who want to learn German. The following feature ideas outline planned functionality:
 
 ## Planned Features
 
-- **Word Lookup and Definitions** – Search for words and view definitions, pronunciations, and usage examples.
-- **Vocabulary Lists** – Create, manage, or import word lists for study.
-- **Progress Tracking** – Track user performance on quizzes or practice sessions.
-- **Offline Access** – Access core vocabulary features without an internet connection.
+- **Turkish–German Word Lookup** – Search for words in either language and see German definitions with Turkish explanations.
+- **German Pronunciation Audio** – Listen to native-speaker pronunciations.
+- **Daily German Words with Turkish Translations** – Expand vocabulary with daily word notifications.
+- **Vocabulary Lists** – Create, manage, or import custom word lists.
+- **Progress Tracking** – Monitor quiz results and study sessions.
+- **Grammar Tips in Turkish** – Learn essential German grammar explained in Turkish.
+- **Example Sentences** – Read German example sentences with Turkish translations.
+- **Offline Access** – Continue studying even without an internet connection.
 - **Personalized Quizzes** – Generate quizzes or flashcards from custom word lists.
-- **Audio Pronunciations** – Listen to correct pronunciations for words.
-- **Synonym/Antonym Lookup** – Browse related words to broaden vocabulary knowledge.
-- **Daily Word Suggestions** – Receive a "word of the day" with definitions and examples.
+- **Synonym/Antonym Lookup** – Browse related words to broaden vocabulary.
 - **Gamification** – Earn achievements or streaks for regular practice.
 - **Cross-Platform Sync** – Synchronize progress and word lists across devices via cloud storage.
 


### PR DESCRIPTION
## Summary
- describe the app as a Turkish–German vocabulary trainer
- highlight features such as Turkish–German lookup, German audio, daily words, grammar tips, and more

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68429877d618832a9425a77801706d43